### PR TITLE
Add binary dump method

### DIFF
--- a/scripts/ancillary.py
+++ b/scripts/ancillary.py
@@ -17,6 +17,25 @@ np.seterr(divide='ignore')
 
 MASK = 'mask.nii'
 
+def saveBin(path, arr):
+    with open(path, 'wb+') as fh:
+        header = '%s' % str(arr.dtype)
+        for index in arr.shape:
+            header += ' %d' % index
+        header += '\n'
+        fh.write(header.encode())
+        fh.write(arr.data.tobytes())
+        os.fsync(fh)
+
+def loadBin(path):
+    with open(path, 'rb') as fh:
+        header = fh.readline().decode().split()
+        dtype = header.pop(0)
+        arrayDimensions = []
+        for dimension in header:
+            arrayDimensions.append(int(dimension))
+        arrayDimensions = tuple(arrayDimensions)
+        return np.frombuffer(fh.read(), dtype=dtype).reshape(arrayDimensions)
 
 def encode_png(args):
     """Serialize png images."""

--- a/scripts/local.py
+++ b/scripts/local.py
@@ -23,7 +23,6 @@ from ancillary import saveBin, loadBin
 warnings.simplefilter("ignore")
 
 
-
 def local_0(args):
     """ The first function in the local computation chain
     """

--- a/scripts/local.py
+++ b/scripts/local.py
@@ -85,7 +85,6 @@ def local_1(args):
 
     # Writing covariates and dependents to cache as files
     saveBin(os.path.join(cache_dir, 'X.npy'), biased_X)
-    # saveBin(os.path.join(cache_dir, 'y.npy'), y)
     saveBin(os.path.join(cache_dir, 'y.npy'), y)
 
     # Writing XTX and XTy to output as files
@@ -148,7 +147,6 @@ def local_2(args):
     cache_dir = state_["cacheDirectory"]
 
     biased_X = loadBin(os.path.join(cache_dir, cache_["covariates"]))
-    # y = loadBin(os.path.join(cache_dir, cache_["dependents"]))
     y = loadBin(os.path.join(cache_dir, cache_["dependents"]))
 
     #    avg_beta_vector = input_["avg_beta_vector"]

--- a/scripts/local.py
+++ b/scripts/local.py
@@ -18,8 +18,10 @@ from nipype_utils import average_nifti
 from parsers import parse_for_categorical
 from rw_utils import write_file
 from utils import list_recursive
+from ancillary import saveBin, loadBin
 
 warnings.simplefilter("ignore")
+
 
 
 def local_0(args):
@@ -83,12 +85,13 @@ def local_1(args):
     Xtransposey_local = multiply(biased_X, y)
 
     # Writing covariates and dependents to cache as files
-    np.save(os.path.join(cache_dir, 'X.npy'), biased_X)
-    np.save(os.path.join(cache_dir, 'y.npy'), y)
+    saveBin(os.path.join(cache_dir, 'X.npy'), biased_X)
+    # saveBin(os.path.join(cache_dir, 'y.npy'), y)
+    saveBin(os.path.join(cache_dir, 'y.npy'), y)
 
     # Writing XTX and XTy to output as files
-    np.save(os.path.join(output_dir, 'XTX.npy'), XtransposeX_local)
-    np.save(os.path.join(output_dir, 'XTy.npy'), Xtransposey_local)
+    saveBin(os.path.join(output_dir, 'XTX.npy'), XtransposeX_local)
+    saveBin(os.path.join(output_dir, 'XTy.npy'), Xtransposey_local)
 
     output_dict = {
         "XtransposeX_local": 'XTX.npy',
@@ -145,17 +148,18 @@ def local_2(args):
     state_ = args["state"]
     cache_dir = state_["cacheDirectory"]
 
-    biased_X = np.load(os.path.join(cache_dir, cache_["covariates"]))
-    y = np.load(os.path.join(cache_dir, cache_["dependents"]))
+    biased_X = loadBin(os.path.join(cache_dir, cache_["covariates"]))
+    # y = loadBin(os.path.join(cache_dir, cache_["dependents"]))
+    y = loadBin(os.path.join(cache_dir, cache_["dependents"]))
 
     #    avg_beta_vector = input_["avg_beta_vector"]
     #    mean_y_global = input_["mean_y_global"]
 
-    avg_beta_vector = np.load(
+    avg_beta_vector = loadBin(
         os.path.join(args["state"]["baseDirectory"],
                      input_["avg_beta_vector"]))
 
-    mean_y_global = np.load(
+    mean_y_global = loadBin(
         os.path.join(args["state"]["baseDirectory"], input_["mean_y_global"]))
 
     varX_matrix_local = multiply(biased_X, biased_X)

--- a/scripts/remote.py
+++ b/scripts/remote.py
@@ -13,7 +13,7 @@ import pandas as pd
 import ujson as json
 from scipy import stats
 
-from ancillary import encode_png, print_beta_images, print_pvals
+from ancillary import encode_png, print_beta_images, print_pvals, saveBin, loadBin
 from nipype_utils import calculate_mask
 from remote_ancillary import remote_stats, return_uniques_and_counts
 from rw_utils import read_file
@@ -73,14 +73,14 @@ def remote_1(args):
     ]
 
     beta_vector_0 = sum([
-        np.load(
+        loadBin(
             os.path.join(input_dir, site,
                          input_list[site]["XtransposeX_local"]))
         for site in input_list
     ])
 
     beta_vector_1 = sum([
-        np.load(
+        loadBin(
             os.path.join(input_dir, site,
                          input_list[site]["Xtransposey_local"]))
         for site in input_list
@@ -104,14 +104,14 @@ def remote_1(args):
 
     dof_global = sum(count_y_local) - avg_beta_vector.shape[1]
 
-    np.save(
+    saveBin(
         os.path.join(args["state"]["transferDirectory"],
                      'avg_beta_vector.npy'), avg_beta_vector)
-    np.save(
+    saveBin(
         os.path.join(args["state"]["transferDirectory"], 'mean_y_global.npy'),
         mean_y_global)
 
-    np.save(
+    saveBin(
         os.path.join(args["state"]["cacheDirectory"], 'avg_beta_vector.npy'),
         avg_beta_vector)
 
@@ -198,7 +198,7 @@ def remote_2(args):
     #    avg_beta_vector = cache_list["avg_beta_vector"]
     #    dof_global = cache_list["dof_global"]
 
-    avg_beta_vector = np.load(
+    avg_beta_vector = loadBin(
         os.path.join(cache_dir, cache_list["avg_beta_vector"]))
     dof_global = cache_list["dof_global"]
 


### PR DESCRIPTION
There seem to be issues with numpy's dump method this PR fixes those by making a dump method that can save and load arrays of any size and dtype to disk in a simple binary format.